### PR TITLE
fix: use version-sort for sorting git tags for terragrunt repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN set -eux \
 	&& if [ "${TG_VERSION}" = "latest" ]; then \
 		VERSION="$( git describe --abbrev=0 --tags )"; \
 	else \
-		VERSION="$( git tag | grep -E "v${TG_VERSION}\.[.0-9]+" | sort -u | tail -1 )" ;\
+		VERSION="$( git tag | grep -E "v${TG_VERSION}\.[.0-9]+" | sort -Vu | tail -1 )" ;\
 	fi \
 	&& curl -sS -L \
 		https://github.com/gruntwork-io/terragrunt/releases/download/${VERSION}/terragrunt_linux_amd64 \


### PR DESCRIPTION
Hey, noticed today that 0.12-0.23 rolling release tag have outdated terragrunt version installed, looks like it's sorting issue:

```
➜  ~/pr/q/terragrunt git:(master) git tag | grep -E "v${TG_VERSION}\.[.0-9]+" | sort -Vu | tail -1
v0.23.34
➜  ~/pr/q/terragrunt git:(master) git tag | grep -E "v${TG_VERSION}\.[.0-9]+" | sort -u | tail -1
v0.23.9
```

This PR should fix that