### PR TITLE
Fix Terraform versions parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ RUN set -eux \
 	&& if [ "${TF_VERSION}" = "latest" ]; then \
 		VERSION="$( curl -sS https://releases.hashicorp.com/terraform/ \
 			| tac | tac \
-			| grep -Eo '/[.0-9]+/' \
+			| grep -Eo '/terraform/[.0-9]+' \
 			| grep -Eo '[.0-9]+' \
 			| sort -V \
 			| tail -1 )"; \
 	else \
 		VERSION="$( curl -sS https://releases.hashicorp.com/terraform/ \
 			| tac | tac \
-			| grep -Eo "/${TF_VERSION}\.[.0-9]+/" \
+			| grep -Eo "/terraform/${TF_VERSION}\.[.0-9]+" \
 			| grep -Eo '[.0-9]+' \
 			| sort -V \
 			| tail -1 )"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ RUN set -eux \
 	&& if [ "${TF_VERSION}" = "latest" ]; then \
 		VERSION="$( curl -sS https://releases.hashicorp.com/terraform/ \
 			| tac | tac \
-			| grep -Eo '/terraform/[.0-9]+' \
+			| grep -Eo '/terraform/[.0-9]+\"' \
 			| grep -Eo '[.0-9]+' \
 			| sort -V \
 			| tail -1 )"; \
 	else \
 		VERSION="$( curl -sS https://releases.hashicorp.com/terraform/ \
 			| tac | tac \
-			| grep -Eo "/terraform/${TF_VERSION}\.[.0-9]+" \
+			| grep -Eo "/terraform/${TF_VERSION}\.[.0-9]+\"" \
 			| grep -Eo '[.0-9]+' \
 			| sort -V \
 			| tail -1 )"; \

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ _test-tf-version:
 		LATEST="$$( \
 			curl -L -sS https://releases.hashicorp.com/terraform/ \
 			| tac | tac \
-			| grep -Eo '/[.0-9]+/' \
+			| grep -Eo '/[.0-9]+' \
 			| grep -Eo '[.0-9]+' \
 			| sort -u \
 			| sort -V \

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ _test-tf-version:
 		LATEST="$$( \
 			curl -L -sS https://releases.hashicorp.com/terraform/ \
 			| tac | tac \
-			| grep -Eo '/[.0-9]+' \
+			| grep -Eo '/terraform/[.0-9]+\"' \
 			| grep -Eo '[.0-9]+' \
 			| sort -u \
 			| sort -V \


### PR DESCRIPTION
Hashicorp seems to have changed the Terraform release page.
The URLs of the page have changed from `/terraform/1.0.0/` to `/terraform/1.0.0`
The parsing has been broken, which prevents any new build...