### PR TITLE
Fix version regex for terragrunt test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ _test-tg-version:
 		fi; \
 	else \
 		echo "Testing for tag: $(TG_VERSION)"; \
-		if ! docker run --rm --platform $(ARCH) $(IMAGE):$(DOCKER_TAG) terragrunt --version | grep -E "^terragrunt[[:space:]]*version[[:space:]]*v?$(TG_VERSION)\.[.0-9]+$$"; then \
+		if ! docker run --rm --platform $(ARCH) $(IMAGE):$(DOCKER_TAG) terragrunt --version | grep -E "^terragrunt[[:space:]]*version[[:space:]]*v?$(TG_VERSION)\.[.0-9]+(-[-a-z0-9]+)?$$"; then \
 			echo "Failed"; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
Latest version of **terragrunt** `0.48.x` does not pass regex test:

```
$ docker run --rm cytopia/terragrunt:1.4-0.48-0.35 terragrunt --version
root> terragrunt --version
terragrunt version v0.48.7-test-signing-binaries
```